### PR TITLE
Fix ESPHome 2025.2 compatibility (initial state + actions)

### DIFF
--- a/components/pkt4_mcu/pkt4_mcu.cpp
+++ b/components/pkt4_mcu/pkt4_mcu.cpp
@@ -82,7 +82,10 @@ void PKT4MCUComponent::loop() {
 						if (this->tray_sensor_) {
 							if (!data->tray_open && !!data->tray_closed) this->tray_sensor_->publish_state(true);
 							else if (!data->tray_closed && !!data->tray_open) this->tray_sensor_->publish_state(false);
-							else this->tray_sensor_->invalidate_state();
+							else {
+								// ESPHome 2025.x removed BinarySensor::invalidate_state().
+								// If MCU reports an ambiguous tray state (both/neither), keep last known state.
+							}
 						}
 						if (this->bin_sensor_) this->bin_sensor_->publish_state(data->bin_present);
 						if (data->unk0) ESP_LOGW(TAG, "0x1.0 has unknown bits set: %X", data->unk);

--- a/components/pkt4_mcu/pkt4_mcu.h
+++ b/components/pkt4_mcu/pkt4_mcu.h
@@ -63,12 +63,18 @@ class PKT4MCUComponent: public Component, public uart::UARTDevice {
 
 template<typename... Ts> class InitAction: public Action<Ts...>, public Parented<PKT4MCUComponent> {
 	public:
-		void play(const Ts &...x) override { this->parent_->init(); }
+		void play(Ts... x) override {
+			(void) sizeof...(x);
+			this->parent_->init();
+		}
 };
 
 template<typename... Ts> class DeinitAction: public Action<Ts...>, public Parented<PKT4MCUComponent> {
 	public:
-		void play(const Ts &...x) override { this->parent_->deinit(); }
+		void play(Ts... x) override {
+			(void) sizeof...(x);
+			this->parent_->deinit();
+		}
 };
 
 template<typename... Ts> class MotorAction: public Action<Ts...>, public Parented<PKT4MCUComponent> {
@@ -80,7 +86,10 @@ template<typename... Ts> class MotorAction: public Action<Ts...>, public Parente
 		void set_duration(uint16_t duration) { this->duration_ = duration; }
 		void set_timeout(uint16_t timeout) { this->timeout_ = timeout; }
 
-		void play(const Ts &...x) override { this->parent_->motor(this->motor_, this->mode_, this->direction_, this->speed_, this->duration_, this->timeout_); }
+		void play(Ts... x) override {
+			(void) sizeof...(x);
+			this->parent_->motor(this->motor_, this->mode_, this->direction_, this->speed_, this->duration_, this->timeout_);
+		}
 
 	protected:
 		uint8_t motor_, mode_, direction_, speed_{0};

--- a/petkit.yaml
+++ b/petkit.yaml
@@ -607,7 +607,7 @@ binary_sensor:
       id: drum_level
       name: Drum Level
       entity_category: diagnostic
-      trigger_on_initial_state: true
+      publish_initial_state: true
       on_press:
         globals.set:
           id: level_needed
@@ -644,7 +644,7 @@ binary_sensor:
       name: Tray
       entity_category: diagnostic
       disabled_by_default: true
-      trigger_on_initial_state: true
+      publish_initial_state: true
       on_state:
         pkt4_mcu.motor:
           motor: tray
@@ -742,7 +742,7 @@ binary_sensor:
     pin:
       number: GPIO22
       allow_other_uses: true
-    trigger_on_initial_state: true
+    publish_initial_state: true
     on_press:  # ready
       pkt4_mcu.init:
     on_release:  # reset


### PR DESCRIPTION
*Summary*
This updates the Petkit T4 ESPHome config + custom component to compile and validate cleanly on ESPHome 2025.2.x by replacing deprecated/removed APIs and options.

**Changes**
- Replace deprecated YAML option `trigger_on_initial_state` with `publish_initial_state` in petkit.yaml.
- Remove use of removed `BinarySensor::invalidate_state()` in pkt4_mcu.cpp; ambiguous tray flag states now keep the last known state.
- Update custom automation action implementations to match current ESPHome `Action::play(Ts...)` signature in pkt4_mcu.h.